### PR TITLE
Add pip to the launch layer.

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -13,6 +13,7 @@ import (
 type BuildPlanMetadata struct {
 	// Build denotes the dependency is needed at build-time.
 	Build bool `toml:"build"`
+	Launch bool `toml:"launch"`
 }
 
 // Detect will return a packit.DetectFunc that will be invoked during the
@@ -47,6 +48,7 @@ func Detect() packit.DetectFunc {
 						Name: Pip,
 						Metadata: BuildPlanMetadata{
 							Build: true,
+							Launch: true,
 						},
 					},
 				},


### PR DESCRIPTION
Part of https://github.com/plotly/dekn/issues/483
Part of https://github.com/plotly/dekn/issues/536
Should also fix https://github.com/plotly/dekn/issues/365#issuecomment-926240206

We have 2 distinct builpacks related to pip, the `paketo-buildpacks/pip` and the `paketo-buildpacks/pip-install`. The first one is responsible for the installation of `pip` itself while the second one is responsible for the `requirement.txt` dependencies. By default, only the `pip-install` builpack saves a layer for the run time. This change allow the `pip` to save its layer too for the run time image.

@BRONSOLO (cc @homer6 ) please review.