### PR TITLE
fix: [plotly/dekn#6244] add jammy support

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -13,3 +13,6 @@ api = "0.6"
 
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"
+
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"


### PR DESCRIPTION
see plotly/dekn#6244

Because we upgraded https://github.com/plotly/dek-dash-app-builder/pull/18 

we need to ensure all component support jammy version