### PR TITLE
Fix architecture and image format

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,6 +49,7 @@ function run::build() {
 
       GOOS=linux \
       CGO_ENABLED=0 \
+      GOARCH="amd64" \
         go build \
           -ldflags="-s -w" \
           -o "run" \
@@ -77,6 +78,7 @@ function cmd::build() {
 
       GOOS="linux" \
       CGO_ENABLED=0 \
+      GOARCH="amd64" \
         go build \
           -ldflags="-s -w" \
           -o "${BUILDPACKDIR}/bin/${name}" \

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -140,7 +140,7 @@ function buildpackage::create() {
   pack \
     buildpack package "${output}" \
       --path "${BUILD_DIR}/buildpack.tgz" \
-      --format file
+      --format image
 }
 
 main "${@:-}"


### PR DESCRIPTION
See: https://github.com/plotly/dekn/issues/6374

So that we are not dependent on machine where the buildpack is build (until it's automated).